### PR TITLE
custom lambda authorizer 테스트를 위해 object 추가

### DIFF
--- a/rwlambdaTester.js
+++ b/rwlambdaTester.js
@@ -195,7 +195,8 @@ function test(configFilePath = 'test_config.yml', lambdaPath = "/src/lambda/") {
                     authorizer: {
                         jwt: {
                             claims: testDirection.claimsProfiles ? testDirection.claimsProfiles[item.claimsProfile] : undefined
-                        }
+                        },
+                        lambda: testDirection.claimsProfiles ? testDirection.claimsProfiles[item.claimsProfile] : undefined
                     }
                 }
             }


### PR DESCRIPTION
API Gateway Authorizer로 lambda를 사용하면 response를 `event.requestContext.authorizer.lambda`에 담아주어서 동일하게 테스트 할 수 있도록 해당 사항 반영