### PR TITLE
lambda_authorizer_config

### DIFF
--- a/rwlambdaTester.js
+++ b/rwlambdaTester.js
@@ -110,6 +110,13 @@ function _iterateExpect(response, value, path = "") {
     }
 }
 
+async function handleAuthorizer(authorizer,token) {
+    const authorizerEvent = { headers: {authorization: `Bearer ${token}`}}
+    const result = (await authorizer.handler(authorizerEvent)).context
+    console.log(result)
+    return result
+}
+
 expect.extend({
     myToBe(response, value) {
         const pass = response.statusCode == value;
@@ -137,6 +144,8 @@ function test(configFilePath = 'test_config.yml', lambdaPath = "/src/lambda/") {
     process.env.testing = true;
     var test_config = fs.readFileSync(configFilePath, 'utf8')
     const testDirection = YAML.parse(test_config);
+    // authorizer 설정
+    const authorizer =  testDirection.authorizer? require(appRoot +lambdaPath + testDirection.authorizer) : null
     beforeAll(async () => {
         //기본 설정
 
@@ -187,7 +196,14 @@ function test(configFilePath = 'test_config.yml', lambdaPath = "/src/lambda/") {
         const mod = require(appRoot + lambdaPath + item.uri);
         const lambdaWrapper = jestPlugin.lambdaWrapper;
         const wrapped = lambdaWrapper.wrap(mod, { handler: 'handler' });
+        
+        const useAuthorizer = require(appRoot+lambdaPath+item.uri).apiSpec.event[0].authorizer? true : false
+
         it(item.uri + ((item.description) ? " " + item.description : ""), async () => {
+            let authorizer_result = testDirection.claimsProfiles ? testDirection.claimsProfiles[item.claimsProfile] : undefined
+            const authorizer_token = getValue(item.token)
+            authorizer_result = authorizer &&  useAuthorizer ? await handleAuthorizer(authorizer, authorizer_token) : authorizer_result
+
             let input = {
                 queryStringParameters: item.parms, body: JSON.stringify(item.parms),
                 requestContext:
@@ -196,11 +212,12 @@ function test(configFilePath = 'test_config.yml', lambdaPath = "/src/lambda/") {
                         jwt: {
                             claims: testDirection.claimsProfiles ? testDirection.claimsProfiles[item.claimsProfile] : undefined
                         },
-                        lambda: testDirection.claimsProfiles ? testDirection.claimsProfiles[item.claimsProfile] : undefined
+                        // apiSpec에 authorizer설정되어있고 + authorizer 경로가 test에 넣어져 있으면 authorizer돌린 결과를 주기
+                        // item.header에 jwt가 설정되어있어야함
+                        lambda: authorizer_result
                     }
                 }
             }
-
 
             if (item.parms) {
                 if (typeof item.parms == 'string') {

--- a/rwlambdaTester.js
+++ b/rwlambdaTester.js
@@ -113,7 +113,6 @@ function _iterateExpect(response, value, path = "") {
 async function handleAuthorizer(authorizer,token) {
     const authorizerEvent = { headers: {authorization: `Bearer ${token}`}}
     const result = (await authorizer.handler(authorizerEvent)).context
-    console.log(result)
     return result
 }
 


### PR DESCRIPTION
test yml에
**authorizer: authorizer/authorizer.js** (람다 authorizer의 경로)
넣으면
해당 test_target apiSpec에 authorizer가 있는지 확인하고
있으면 authorizer를 돌리는데

test_targets:
  - uri: user/oauth/post.js
    description: oauth user_status = confirmed로 전환
    method: post
    **token: '@token'**
    parms:
      marketing_agreed: true
    expect:
      checkType: check_200
위와 같이 이전 테스트에서 저장된 토큰을 넣으면 headers에 token이 들어가서 authorizer가 잘 수행되도록 해놓았습니다